### PR TITLE
Marshal support for PipelineDB's HyperLogLog structure.

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -1,0 +1,85 @@
+package hllpp
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+type pipelineHLL struct {
+	Encoding byte
+	_        [3]byte
+	Card     uint64
+	P        uint8
+	_        [3]byte
+	Mlen     int32
+	// M is variable-length, and must be dealt with separately.
+}
+
+const (
+	encodingDenseDirty    = 'd'
+	encodingDenseClean    = 'D'
+	encodingExplicitDirty = 'e'
+	encodingExplicitClean = 'E'
+)
+
+// Converts dense or sparse data structure to clean Pipeline format (0.8.5
+// vintage on x64)
+func (h *HLLPP) AsPipeline() (bytes.Buffer, error) {
+	p := pipelineHLL{Card: h.Count()}
+
+	// Always use the clean encoding, as we have just calculated the
+	// cardinality.
+	if h.sparse {
+		h.flushTmpSet()
+
+		p.Encoding = encodingExplicitClean
+		p.P = uint8(h.pp)
+		p.Mlen = int32(h.sparseLength * 4)
+	} else {
+		p.Encoding = encodingDenseClean
+		p.P = h.p
+		p.Mlen = int32(len(h.data))
+	}
+
+	// Write the size-invariant preamble.
+	var ret bytes.Buffer
+	if err := binary.Write(&ret, binary.LittleEndian, &p); err != nil {
+		return ret, err
+	}
+
+	if h.sparse {
+		// Retailnext sparse encoding is not the same as Pipeline's SPARSE
+		// encoding. It's actually the EXPLICIT encoding in Pipeline.
+		output := h.sparseToExplicit()
+		if err := binary.Write(&ret, binary.LittleEndian, &output); err != nil {
+			return ret, err
+		}
+	} else {
+		// Dense representation is fully compatible as-is.
+		if _, err := ret.Write(h.data); err != nil {
+			return ret, err
+		}
+	}
+
+	return ret, nil
+}
+
+// Converts retailnext (index, rho) tuples from its encoding named 'sparse'
+// into the 'explicit' encoding used by Pipeline, which is the same but packed
+// into a uint32. It also does not use the 'difference encoding' described in
+// the paper, as retailnext's implementation does.
+func (h *HLLPP) sparseToExplicit() []uint32 {
+	reader := newSparseReader(h.data)
+	var output []uint32
+	for !reader.Done() {
+		idx, r := h.decodeHash(reader.Next(), h.pp)
+		if r > 0xff {
+			panic("register value would be truncated")
+		} else if idx > 0xffffff {
+			panic("register index would be truncated")
+		}
+		// 24 bits of register ID, 8 bits of register value.
+		output = append(output, (idx<<8)|uint32(r&0xff))
+	}
+	return output
+}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,0 +1,57 @@
+package hllpp
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"testing"
+)
+
+// Number of iterations to test pipeline marshaling on. A high number here
+// ensures that both dense and sparse (explicit) marshaling will be tested.
+const iterations = 8000
+
+func TestPipelineMarshal(t *testing.T) {
+	var h = New()
+
+	for i := 0; i < iterations; i++ {
+		random := make([]byte, 32)
+		if _, err := rand.Read(random); err != nil {
+			t.Error(err)
+		}
+		h.Add(random)
+
+		if h.sparse {
+			h.flushTmpSet()
+		}
+
+		if buf, err := h.AsPipeline(); err != nil {
+			t.Error(err)
+		} else if err = checkPipelineMarshal(h, buf.Bytes()); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func checkPipelineMarshal(h *HLLPP, b []byte) error {
+	var preamble pipelineHLL
+
+	buf := bytes.NewBuffer(b)
+	if err := binary.Read(buf, binary.LittleEndian, &preamble); err != nil {
+		return err
+	}
+
+	if preamble.Encoding != encodingExplicitClean && preamble.Encoding != encodingDenseClean {
+		return fmt.Errorf("unexpected encoding: %c", preamble.Encoding)
+	}
+
+	data := make([]byte, preamble.Mlen)
+	if n, err := buf.Read(data); err != nil {
+		return err
+	} else if int32(n) != preamble.Mlen {
+		return fmt.Errorf("short read expected %d bytes got %d", preamble.Mlen, n)
+	}
+
+	return nil
+}


### PR DESCRIPTION
(As compiled on x64 and observed on database-2.)

Mimic the HyperLogLog structure and serialize a retailnext HLLPP object
to this structure. It needs to have the same padding as the one observed
on database-2. Ideally, the PipelineDB version should be packed and
versioned, but doing so would invalidate our existing HyperLogLogs in
the database. For now, we'll just match the one that we use.

Issue arbortech/workspace#1437

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arbortech/hllpp/1)

<!-- Reviewable:end -->
