### PR TITLE
More work on PipelineDB converter.

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -11,75 +11,132 @@ type pipelineHLL struct {
 	Card     uint64
 	P        uint8
 	_        [3]byte
-	Mlen     int32
+	Mlen     uint32
 	// M is variable-length, and must be dealt with separately.
 }
 
 const (
-	encodingDenseDirty    = 'd'
-	encodingDenseClean    = 'D'
-	encodingExplicitDirty = 'e'
-	encodingExplicitClean = 'E'
+	// Public constants.
+	PipelineDenseDirty    = 'd'
+	PipelineDenseClean    = 'D'
+	PipelineExplicitDirty = 'e'
+	PipelineExplicitClean = 'E'
+
+	// Private constants.
+	pipelineBitsPerRegister = 6
+
+	// Feature flags.
+
+	// Whether to always write 'dense' PipelineDB HLLs. Currently, this is true because
+	// I observe cardinality / union issues when taking the union of explicit
+	// PipelineDB HLLs that were converted from Retailnext.
+	alwaysWriteDense = true
+
+	// Whether to mark the cardinality calculation as clean or dirty. Clean is
+	// better for production, but dirty is better for testing.
+	writeDirtyEncoding = true
 )
 
 // Converts dense or sparse data structure to clean Pipeline format (0.8.5
 // vintage on x64)
-func (h *HLLPP) AsPipeline() (bytes.Buffer, error) {
-	p := pipelineHLL{Card: h.Count()}
+func (h *HLLPP) AsPipeline() ([]byte, error) {
+	p := pipelineHLL{
+		Card: h.Count(),
+		P:    h.p,
+	}
 
-	// Always use the clean encoding, as we have just calculated the
-	// cardinality.
-	if h.sparse {
-		h.flushTmpSet()
+	var data []byte
+	var dense bool = !h.sparse || alwaysWriteDense
 
-		p.Encoding = encodingExplicitClean
-		p.P = uint8(h.pp)
-		p.Mlen = int32(h.sparseLength * 4)
+	if dense {
+		if writeDirtyEncoding {
+			p.Encoding = PipelineDenseDirty
+		} else {
+			p.Encoding = PipelineDenseClean
+		}
+
+		p.Mlen = 1 + h.m*pipelineBitsPerRegister/8
+		data = make([]byte, p.Mlen)
 	} else {
-		p.Encoding = encodingDenseClean
-		p.P = h.p
-		p.Mlen = int32(len(h.data))
+		if writeDirtyEncoding {
+			p.Encoding = PipelineExplicitDirty
+		} else {
+			p.Encoding = PipelineDenseClean
+		}
+		p.Mlen = 4 * h.sparseLength
 	}
 
 	// Write the size-invariant preamble.
 	var ret bytes.Buffer
 	if err := binary.Write(&ret, binary.LittleEndian, &p); err != nil {
-		return ret, err
+		return nil, err
 	}
 
-	if h.sparse {
-		// Retailnext sparse encoding is not the same as Pipeline's SPARSE
-		// encoding. It's actually the EXPLICIT encoding in Pipeline.
-		output := h.sparseToExplicit()
-		if err := binary.Write(&ret, binary.LittleEndian, &output); err != nil {
-			return ret, err
-		}
-	} else {
-		// Dense representation is fully compatible as-is.
-		if _, err := ret.Write(h.data); err != nil {
-			return ret, err
+	// Read registers out of Retailnext implementation and write to whichever
+	// format we selected above.
+	for it := newRegIterator(h); !it.done(); {
+		reg, val := it.next()
+		if dense {
+			setDensePipelineRegister(data, reg, val)
+		} else {
+			binary.Write(&ret, binary.LittleEndian, uint32(reg<<8)|uint32(val&0xff))
 		}
 	}
 
-	return ret, nil
+	// |data| only used when writing DENSE representation.
+	if dense {
+		if _, err := ret.Write(data); err != nil {
+			return nil, err
+		}
+	}
+
+	return ret.Bytes(), nil
 }
 
-// Converts retailnext (index, rho) tuples from its encoding named 'sparse'
-// into the 'explicit' encoding used by Pipeline, which is the same but packed
-// into a uint32. It also does not use the 'difference encoding' described in
-// the paper, as retailnext's implementation does.
-func (h *HLLPP) sparseToExplicit() []uint32 {
-	reader := newSparseReader(h.data)
-	var output []uint32
-	for !reader.Done() {
-		idx, r := h.decodeHash(reader.Next(), h.pp)
-		if r > 0xff {
-			panic("register value would be truncated")
-		} else if idx > 0xffffff {
-			panic("register index would be truncated")
-		}
-		// 24 bits of register ID, 8 bits of register value.
-		output = append(output, (idx<<8)|uint32(r&0xff))
+// Straight port of HLL_DENSE_SET_REGISTER macro. dense.go's setRegister is
+// subtly different in ways yet to be determined.
+func setDensePipelineRegister(_p []byte, regnum uint32, val uint8) {
+	var _byte uint32 = regnum * pipelineBitsPerRegister / 8
+	var _fb uint32 = regnum * pipelineBitsPerRegister & 7
+	var _fb8 uint32 = 8 - _fb
+	var _v uint32 = uint32(val)
+
+	var hllRegisterMax uint32 = (1 << pipelineBitsPerRegister) - 1
+	_p[_byte] &= uint8(^(hllRegisterMax << _fb))
+	_p[_byte] |= uint8(_v << _fb)
+	_p[_byte+1] &= uint8(^(hllRegisterMax >> _fb8))
+	_p[_byte+1] |= uint8(_v >> _fb8)
+}
+
+// Backing-agnostic iterator of HLL registers.
+type regIterator struct {
+	hll *HLLPP
+	sr  *sparseReader
+	idx uint32
+}
+
+func newRegIterator(h *HLLPP) *regIterator {
+	it := regIterator{hll: h}
+	if h.sparse {
+		it.sr = newSparseReader(h.data)
 	}
-	return output
+	return &it
+}
+
+func (i *regIterator) done() bool {
+	if i.hll.sparse {
+		return i.sr.Done()
+	} else {
+		return i.idx == i.hll.m
+	}
+}
+
+func (i *regIterator) next() (reg uint32, val uint8) {
+	if i.hll.sparse {
+		return i.hll.decodeHash(i.sr.Next(), i.hll.p)
+	} else {
+		reg, val := i.idx, getRegister(i.hll.data, i.hll.bitsPerRegister, i.idx)
+		i.idx++
+		return reg, val
+	}
 }

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -28,7 +28,7 @@ func TestPipelineMarshal(t *testing.T) {
 
 		if buf, err := h.AsPipeline(); err != nil {
 			t.Error(err)
-		} else if err = checkPipelineMarshal(h, buf.Bytes()); err != nil {
+		} else if err = checkPipelineMarshal(h, buf); err != nil {
 			t.Error(err)
 		}
 	}
@@ -49,7 +49,7 @@ func checkPipelineMarshal(h *HLLPP, b []byte) error {
 	data := make([]byte, preamble.Mlen)
 	if n, err := buf.Read(data); err != nil {
 		return err
-	} else if int32(n) != preamble.Mlen {
+	} else if uint32(n) != preamble.Mlen {
 		return fmt.Errorf("short read expected %d bytes got %d", preamble.Mlen, n)
 	}
 


### PR DESCRIPTION
- Use an iterator abstraction to separate 'getting all the registers'
  from 'writing out the registers'. Now we don't care what the source
  HLL uses.
- Repair DENSE output by doing a straight port of the register set macro
  from hll.c. I haven't dived into it yet, but the two implementations
  are not byte-compatible.
- In fact, the repaired DENSE output seems to have fewer cardinality
  errors on union operations, so add a flag that causes us to always
  write DENSE representations no matter what the source contained, but
  allow future investigation to reenable writing EXPLICIT PipelineDB
  HLLs.
- Add a feature-flag for enabling the use of the stored cardinality. For
  testing, doing so can mask errors that don't involve union operations.
  But in production, we can probably use it.

Issue #1437

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arbortech/hllpp/2)

<!-- Reviewable:end -->
